### PR TITLE
feat(i18n): add LLM prompt setting labels

### DIFF
--- a/ar/common.json
+++ b/ar/common.json
@@ -71,7 +71,9 @@
       "targetLanguage": "اللغة المستهدفة",
       "targetLanguageDescription": "Language to translate the story into.",
       "displayOptions": "Display Options",
-      "displayOptionsDescription": "Show original text"
+      "displayOptionsDescription": "Show original text",
+      "additionalSystemPrompt": "Additional System Prompt",
+      "additionalSystemPromptDescription": "Extra instructions appended to the translation prompt."
     },
     "interfaceLanguage": "Interface Language",
     "gameContent": "Game Content",

--- a/ca_ES/common.json
+++ b/ca_ES/common.json
@@ -71,7 +71,9 @@
       "targetLanguage": "Llengua objectiu",
       "targetLanguageDescription": "Language to translate the story into.",
       "displayOptions": "Display Options",
-      "displayOptionsDescription": "Show original text"
+      "displayOptionsDescription": "Show original text",
+      "additionalSystemPrompt": "Additional System Prompt",
+      "additionalSystemPromptDescription": "Extra instructions appended to the translation prompt."
     },
     "interfaceLanguage": "Interface Language",
     "gameContent": "Game Content",

--- a/cs/common.json
+++ b/cs/common.json
@@ -71,7 +71,9 @@
       "targetLanguage": "Zaměřit na jazyk",
       "targetLanguageDescription": "Language to translate the story into.",
       "displayOptions": "Display Options",
-      "displayOptionsDescription": "Show original text"
+      "displayOptionsDescription": "Show original text",
+      "additionalSystemPrompt": "Additional System Prompt",
+      "additionalSystemPromptDescription": "Extra instructions appended to the translation prompt."
     },
     "interfaceLanguage": "Jazyk Rozhrání",
     "gameContent": "Obsah Hry",

--- a/de/common.json
+++ b/de/common.json
@@ -71,7 +71,9 @@
       "targetLanguage": "Zielsprache",
       "targetLanguageDescription": "Language to translate the story into.",
       "displayOptions": "Display Options",
-      "displayOptionsDescription": "Show original text"
+      "displayOptionsDescription": "Show original text",
+      "additionalSystemPrompt": "Additional System Prompt",
+      "additionalSystemPromptDescription": "Extra instructions appended to the translation prompt."
     },
     "interfaceLanguage": "Anzeigesprache",
     "gameContent": "Spielinhalt",

--- a/en/common.json
+++ b/en/common.json
@@ -71,7 +71,9 @@
       "targetLanguage": "Target Language",
       "targetLanguageDescription": "Language to translate the story into.",
       "displayOptions": "Display Options",
-      "displayOptionsDescription": "Show original text"
+      "displayOptionsDescription": "Show original text",
+      "additionalSystemPrompt": "Additional System Prompt",
+      "additionalSystemPromptDescription": "Extra instructions appended to the translation prompt."
     },
     "interfaceLanguage": "Interface Language",
     "gameContent": "Game Content",

--- a/es/common.json
+++ b/es/common.json
@@ -71,7 +71,9 @@
       "targetLanguage": "Idioma final",
       "targetLanguageDescription": "Language to translate the story into.",
       "displayOptions": "Display Options",
-      "displayOptionsDescription": "Show original text"
+      "displayOptionsDescription": "Show original text",
+      "additionalSystemPrompt": "Additional System Prompt",
+      "additionalSystemPromptDescription": "Extra instructions appended to the translation prompt."
     },
     "interfaceLanguage": "Idioma de interfaz ",
     "gameContent": "Contenido del Juego",

--- a/es_419/common.json
+++ b/es_419/common.json
@@ -71,7 +71,9 @@
       "targetLanguage": "Idioma objetivo",
       "targetLanguageDescription": "Language to translate the story into.",
       "displayOptions": "Display Options",
-      "displayOptionsDescription": "Show original text"
+      "displayOptionsDescription": "Show original text",
+      "additionalSystemPrompt": "Additional System Prompt",
+      "additionalSystemPromptDescription": "Extra instructions appended to the translation prompt."
     },
     "interfaceLanguage": "Idioma de la interfaz",
     "gameContent": "Contenido del juego",

--- a/fr/common.json
+++ b/fr/common.json
@@ -71,7 +71,9 @@
       "targetLanguage": "Langue cible",
       "targetLanguageDescription": "Language to translate the story into.",
       "displayOptions": "Display Options",
-      "displayOptionsDescription": "Show original text"
+      "displayOptionsDescription": "Show original text",
+      "additionalSystemPrompt": "Additional System Prompt",
+      "additionalSystemPromptDescription": "Extra instructions appended to the translation prompt."
     },
     "interfaceLanguage": "Langue d'interface",
     "gameContent": "Contenu du jeu",

--- a/he_IL/common.json
+++ b/he_IL/common.json
@@ -62,7 +62,11 @@
     },
     "gameContentTranslationLanguage": "Game Content Translation Community Language",
     "gameContentTranslationLanguageFollowInterface": "Follow Interface Language",
-    "gameContentTranslationRegion": "Game Content Translation Official Region"
+    "gameContentTranslationRegion": "Game Content Translation Official Region",
+    "llm": {
+      "additionalSystemPrompt": "Additional System Prompt",
+      "additionalSystemPromptDescription": "Extra instructions appended to the translation prompt."
+    }
   },
   "support": "עזרה",
   "toolbar": {

--- a/id/common.json
+++ b/id/common.json
@@ -71,7 +71,9 @@
       "targetLanguage": "Bahasa Target",
       "targetLanguageDescription": "Language to translate the story into.",
       "displayOptions": "Display Options",
-      "displayOptionsDescription": "Show original text"
+      "displayOptionsDescription": "Show original text",
+      "additionalSystemPrompt": "Additional System Prompt",
+      "additionalSystemPromptDescription": "Extra instructions appended to the translation prompt."
     },
     "interfaceLanguage": "Interface Language",
     "gameContent": "Game Content",

--- a/it/common.json
+++ b/it/common.json
@@ -71,7 +71,9 @@
       "targetLanguage": "Lingua scelta",
       "targetLanguageDescription": "Language to translate the story into.",
       "displayOptions": "Display Options",
-      "displayOptionsDescription": "Show original text"
+      "displayOptionsDescription": "Show original text",
+      "additionalSystemPrompt": "Additional System Prompt",
+      "additionalSystemPromptDescription": "Extra instructions appended to the translation prompt."
     },
     "interfaceLanguage": "Lingua dell'interfaccia",
     "gameContent": "Contenuto di gioco",

--- a/ja/common.json
+++ b/ja/common.json
@@ -71,7 +71,9 @@
       "targetLanguage": "目的の言語",
       "targetLanguageDescription": "Language to translate the story into.",
       "displayOptions": "Display Options",
-      "displayOptionsDescription": "Show original text"
+      "displayOptionsDescription": "Show original text",
+      "additionalSystemPrompt": "追加システムプロンプト",
+      "additionalSystemPromptDescription": "翻訳プロンプトに追加する指示。"
     },
     "interfaceLanguage": "インターフェース言語",
     "gameContent": "ゲームコンテンツ",

--- a/ko/common.json
+++ b/ko/common.json
@@ -71,7 +71,9 @@
       "targetLanguage": "대상 언어",
       "targetLanguageDescription": "Language to translate the story into.",
       "displayOptions": "Display Options",
-      "displayOptionsDescription": "Show original text"
+      "displayOptionsDescription": "Show original text",
+      "additionalSystemPrompt": "추가 시스템 프롬프트",
+      "additionalSystemPromptDescription": "번역 프롬프트에 추가할 지시사항입니다."
     },
     "interfaceLanguage": "인터페이스 언어",
     "gameContent": "게임 콘텐츠",

--- a/ms/common.json
+++ b/ms/common.json
@@ -71,7 +71,9 @@
       "targetLanguage": "Bahasa Sasaran",
       "targetLanguageDescription": "Language to translate the story into.",
       "displayOptions": "Display Options",
-      "displayOptionsDescription": "Show original text"
+      "displayOptionsDescription": "Show original text",
+      "additionalSystemPrompt": "Additional System Prompt",
+      "additionalSystemPromptDescription": "Extra instructions appended to the translation prompt."
     },
     "interfaceLanguage": "Bahasa Antara Muka",
     "gameContent": "Kandungan Permainan",

--- a/pl/common.json
+++ b/pl/common.json
@@ -71,7 +71,9 @@
       "targetLanguage": "Język docelowy",
       "targetLanguageDescription": "Language to translate the story into.",
       "displayOptions": "Display Options",
-      "displayOptionsDescription": "Show original text"
+      "displayOptionsDescription": "Show original text",
+      "additionalSystemPrompt": "Additional System Prompt",
+      "additionalSystemPromptDescription": "Extra instructions appended to the translation prompt."
     },
     "interfaceLanguage": "Język Interfejsu",
     "gameContent": "Zawartość Gry",

--- a/pt-BR/common.json
+++ b/pt-BR/common.json
@@ -71,7 +71,9 @@
       "targetLanguage": "Idioma de destino",
       "targetLanguageDescription": "Language to translate the story into.",
       "displayOptions": "Display Options",
-      "displayOptionsDescription": "Show original text"
+      "displayOptionsDescription": "Show original text",
+      "additionalSystemPrompt": "Additional System Prompt",
+      "additionalSystemPromptDescription": "Extra instructions appended to the translation prompt."
     },
     "interfaceLanguage": "Linguagem da interface",
     "gameContent": "Conteúdo do jogo",

--- a/pt/common.json
+++ b/pt/common.json
@@ -71,7 +71,9 @@
       "targetLanguage": "Língua-alvo",
       "targetLanguageDescription": "Language to translate the story into.",
       "displayOptions": "Display Options",
-      "displayOptionsDescription": "Show original text"
+      "displayOptionsDescription": "Show original text",
+      "additionalSystemPrompt": "Additional System Prompt",
+      "additionalSystemPromptDescription": "Extra instructions appended to the translation prompt."
     },
     "interfaceLanguage": "Interface Language",
     "gameContent": "Game Content",

--- a/ro/common.json
+++ b/ro/common.json
@@ -71,7 +71,9 @@
       "targetLanguage": "Limba ţintă",
       "targetLanguageDescription": "Language to translate the story into.",
       "displayOptions": "Display Options",
-      "displayOptionsDescription": "Show original text"
+      "displayOptionsDescription": "Show original text",
+      "additionalSystemPrompt": "Additional System Prompt",
+      "additionalSystemPromptDescription": "Extra instructions appended to the translation prompt."
     },
     "interfaceLanguage": "Limba interfaţei",
     "gameContent": "Conţinuturile jocului",

--- a/ru/common.json
+++ b/ru/common.json
@@ -71,7 +71,9 @@
       "targetLanguage": "Целевой язык",
       "targetLanguageDescription": "Language to translate the story into.",
       "displayOptions": "Display Options",
-      "displayOptionsDescription": "Show original text"
+      "displayOptionsDescription": "Show original text",
+      "additionalSystemPrompt": "Additional System Prompt",
+      "additionalSystemPromptDescription": "Extra instructions appended to the translation prompt."
     },
     "interfaceLanguage": "Язык интерфейса",
     "gameContent": "Игровой контент",

--- a/sk_SK/common.json
+++ b/sk_SK/common.json
@@ -71,7 +71,9 @@
       "targetLanguage": "Cieľový jazyk",
       "targetLanguageDescription": "Jazyk, do ktorého sa má príbeh preložiť.",
       "displayOptions": "Nastavenie zobrazenia",
-      "displayOptionsDescription": "Zobraziť pôvodný text"
+      "displayOptionsDescription": "Zobraziť pôvodný text",
+      "additionalSystemPrompt": "Additional System Prompt",
+      "additionalSystemPromptDescription": "Extra instructions appended to the translation prompt."
     },
     "interfaceLanguage": "Jazyk rozhrania",
     "gameContent": "Obsah hry",

--- a/th/common.json
+++ b/th/common.json
@@ -71,7 +71,9 @@
       "targetLanguage": "ภาษาเป้าหมาย",
       "targetLanguageDescription": "ภาษาที่ใช้แปลเนื้อเรื่อง",
       "displayOptions": "ตัวเลือกการแสดงผล",
-      "displayOptionsDescription": "แสดงภาษาต้นฉบับ"
+      "displayOptionsDescription": "แสดงภาษาต้นฉบับ",
+      "additionalSystemPrompt": "Additional System Prompt",
+      "additionalSystemPromptDescription": "Extra instructions appended to the translation prompt."
     },
     "interfaceLanguage": "ภาษาของอินเทอร์เฟซ",
     "gameContent": "เนื้อหาในเกม",

--- a/uk/common.json
+++ b/uk/common.json
@@ -71,7 +71,9 @@
       "targetLanguage": "Мова перекладу",
       "targetLanguageDescription": "Мова, якою перекладати історію",
       "displayOptions": "Параметри відображення",
-      "displayOptionsDescription": "Показати оригінальний текст"
+      "displayOptionsDescription": "Показати оригінальний текст",
+      "additionalSystemPrompt": "Additional System Prompt",
+      "additionalSystemPromptDescription": "Extra instructions appended to the translation prompt."
     },
     "interfaceLanguage": "Мова інтерфейсу",
     "gameContent": "Ігровий контент",

--- a/vi_VN/common.json
+++ b/vi_VN/common.json
@@ -71,7 +71,9 @@
       "targetLanguage": "Ngôn ngữ mục tiêu",
       "targetLanguageDescription": "Language to translate the story into.",
       "displayOptions": "Display Options",
-      "displayOptionsDescription": "Show original text"
+      "displayOptionsDescription": "Show original text",
+      "additionalSystemPrompt": "Additional System Prompt",
+      "additionalSystemPromptDescription": "Extra instructions appended to the translation prompt."
     },
     "interfaceLanguage": "Interface Language",
     "gameContent": "Nội dung trò chơi",

--- a/zh-CN/common.json
+++ b/zh-CN/common.json
@@ -71,7 +71,9 @@
       "targetLanguage": "目标语言",
       "targetLanguageDescription": "故事翻译的目标语言",
       "displayOptions": "显示选项",
-      "displayOptionsDescription": "显示原始文本"
+      "displayOptionsDescription": "显示原始文本",
+      "additionalSystemPrompt": "额外系统提示词",
+      "additionalSystemPromptDescription": "附加到翻译提示词中的指示。"
     },
     "interfaceLanguage": "界面语言",
     "gameContent": "游戏内容",

--- a/zh-TW/common.json
+++ b/zh-TW/common.json
@@ -71,7 +71,9 @@
       "targetLanguage": "目標語言",
       "targetLanguageDescription": "Language to translate the story into.",
       "displayOptions": "顯示選項",
-      "displayOptionsDescription": "顯示原始文本"
+      "displayOptionsDescription": "顯示原始文本",
+      "additionalSystemPrompt": "額外系統提示詞",
+      "additionalSystemPromptDescription": "附加到翻譯提示詞中的指示。"
     },
     "interfaceLanguage": "介面語言",
     "gameContent": "遊戲內容",


### PR DESCRIPTION
Adds the two `settings.llm` translation keys used by sekai-viewer PR #691 to every locale's `common.json` namespace. English, Japanese, Simplified/Traditional Chinese, and Korean use localized text; other locales use the English fallback until translated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Added translated labels and descriptions for the additional system prompt setting in LLM settings.
  * Updated display-options text across supported languages, including Arabic, Chinese, French, German, Japanese, Spanish, and others.
  * Improved consistency of LLM settings terminology across all available locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->